### PR TITLE
Avoid lag burst when a CE grenade explodes

### DIFF
--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -590,6 +590,12 @@ namespace DoorsExpanded
         //GenSpawn
         public static void InvisDoorsDontWipe(BuildableDef newEntDef, BuildableDef oldEntDef, ref bool __result)
         {
+            if (newEntDef.defName.StartsWith("Fragment_") &&
+                oldEntDef.defName.StartsWith("Fragment_"))
+            {
+                return;
+            }
+            
             var oldTrueDef =
                 DefDatabase<ThingDef>.AllDefs.FirstOrDefault(predicate: x => x.defName == oldEntDef.defName);
             var newTrueDef =


### PR DESCRIPTION
When a CE frag grenade explodes, it spawns a large number of "Fragment_GrenadeFrag" entities at the same time (mortar shells spawn "Fragment_Shell" instead)
Running "DefDatabase<ThingDef>.AllDefs.FirstOrDefault()" twice each time is very slow, causing a several-second RimWorld freeze.
Bailing out early on "Fragment_" prefixes seems to work around it, but please check if this would break anything else before accepting this PR, I don't have much of any experience in RimWorld modding.

Fixes #4.